### PR TITLE
Fixed: missing method on newer versions of livewire. Closes #2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,21 @@ export default class SwupLivewirePlugin extends Plugin {
 			el.setAttribute('wire:initial-data', JSON.stringify(data));
 		});
 
-		// Aleays restart Livewire
-		window.Livewire.restart();
+		// Always restart Livewire
+		if (typeof window.Livewire.restart === 'function') {
+			window.Livewire.restart();
+		} else {
+			// handle versions of Livewire that don't have the .restart() method
+			window.Livewire.all().map((component) => {
+				// not always defined - depends on the component
+				if (typeof component.call === 'function') {
+					return component.call('restart');
+				}
+				// alternative version to component.call('restart') in case that doesn't exist
+				if (typeof component.$wire?.$refresh === 'function') {
+					component.$wire.$refresh();
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

![Screen Shot 2024-07-05 at 9 58 00 AM](https://github.com/swup/livewire-plugin/assets/1425304/c098736e-8330-427e-9ec9-86dfc26d1667)

![Screen Shot 2024-07-05 at 9 59 59 AM](https://github.com/swup/livewire-plugin/assets/1425304/27293495-558c-47a1-91dd-e719162efeba)


Seems like `Livewire.restart()` has been removed on newer versions of Livewire.

Some context: https://github.com/livewire/livewire/issues/2334#issuecomment-759901196

So the fix is to only call that function if it exists. Otherwise, we call the restart or refresh methods on the components themselves. Since there seems to be two different ways to restart components, each one is tried if it exists.

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->

**Checks**

Tested with Livewire 3.4 and Swup 4.6.1.

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

I think this can be tagged as 2.1.0 because it is backwards compatible with the previous version and only calls the new code if the old one is missing.

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
